### PR TITLE
Add support for identifying license from github repo url

### DIFF
--- a/lookup_license/format.py
+++ b/lookup_license/format.py
@@ -39,6 +39,10 @@ class TextFormatter(Formatter):
 
     def format_license(self, lic, verbose=False):
         ambigs = []
+
+        if not lic:
+            return None, f'Invalid license {lic}'
+
         if lic['ambiguities'] != 0:
             ambigs = [a['description'] for a in lic['meta']['ambiguities']]
         if verbose:

--- a/lookup_license/ll_shell.py
+++ b/lookup_license/ll_shell.py
@@ -78,6 +78,18 @@ class LookupLicenseShell(cmd.Cmd):
         except Exception as e:
             self.__handle_error(e)
 
+    def do_github(self, arg):
+        """Provide a GitHub repository URL for license lookup. After issuing "github", write the GitHub repository URL to input (stdin) and press enter."""
+        if not self.license_reader:
+            self.license_reader = LicenseTextReader()
+        url = self.license_reader.read_license_url()
+        self.verbose(f'Read {url}, looking up the license')
+        try:
+            result = ll.lookup_github_url(url)
+            self.__output_result(result)
+        except Exception as e:
+            self.__handle_error(e)
+
     def do_verbose(self, arg):
         """Make the interaction more verbose."""
         self.verbose_mode = True

--- a/lookup_license/lookuplicense.py
+++ b/lookup_license/lookuplicense.py
@@ -84,6 +84,13 @@ class LookupLicense():
     def __flame_status(self, res):
         return len(res['ambiguities']) == 0
 
+    def _guess_github_license_url(self, url):
+        if "github" not in url.lower():
+            return None
+        if url.startswith('github.com'):
+            url = f'https://{url}'
+        return [f'{url}/blob/main/LICENSE']
+
     def _fix_url(self, url):
         if "https://github.com" in url:
             url_split = url.split('/')
@@ -159,6 +166,15 @@ class LookupLicense():
         with open(license_file) as fp:
             content = fp.read()
             return self.lookup_license_text(content)
+
+    @cached(cache=LicenseCache(maxsize=MAX_CACHE_SIZE), info=True)
+    def lookup_github_url(self, url):
+        github_urls = self._guess_github_license_url(url)
+        if not github_urls:
+            return None
+        for github_url in github_urls:
+            res = self.lookup_license_url(github_url)
+        return res
 
     @cached(cache=LicenseCache(maxsize=MAX_CACHE_SIZE), info=True)
     def lookup_license_url(self, url):


### PR DESCRIPTION
With the new option `--github` you can supply a GitHub repository url and lookup-license will try to identify the license file for you (by guessing where the license might be located)

Examples:
```
$ lookup-license --github https://github.com/hesa/lookup-license
GPL-3.0-only
```

```
$ lookup-license --github github.com/hesa/lookup-license
GPL-3.0-only
```