### PR TITLE
Add support for cached lookup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ python: py-test py-lint
 
 py-test: 
 	PYTHONPATH=. tests/shell/test-interactive.sh 1
-	PYTHONPATH=. tests/shell/test-cli.sh 1
+	PYTHONPATH=. tests/shell/test-cli.sh --limited
 	PYTHONPATH=. tests/shell/test-multiple.sh 1
 	PYTHONPATH=. pytest tests/python/
 	@echo python tests passed

--- a/lookup_license/__main__.py
+++ b/lookup_license/__main__.py
@@ -45,6 +45,16 @@ def get_parser():
                         help='don±\'t use cache ',
                         default=False)
 
+    parser.add_argument('--clear-cache',
+                        action='store_true',
+                        help='clear the cache ',
+                        default=False)
+
+    parser.add_argument('-uc', '--update-cache',
+                        action='store_true',
+                        help='if the url is already in the cache, update with a new value. This will automatically disable using the cached values',
+                        default=False)
+
     parser.add_argument('-f', '--file',
                         action='store_true',
                         help='read license from file',
@@ -157,10 +167,16 @@ def main():
     if args.verbose > 2:
         logging.basicConfig(force=True, level=logging.DEBUG)
 
-    if args.no_cache:
+    if args.clear_cache:
+        LookupLicenseCache().clear()
+        logging.info('Cache cleared')
+        sys.exit(0)
+
+    if args.update_cache:
+        LookupLicenseCache().set_update_mode(args.update_cache)
+    elif args.no_cache:
         LookupLicenseCache().disable()
-        
-        
+
     ll = LookupLicense()
 
     try:

--- a/lookup_license/__main__.py
+++ b/lookup_license/__main__.py
@@ -14,6 +14,8 @@ from lookup_license.lookuplicense import LicenseTextReader
 from lookup_license.lookupurl.factory import LookupURLFactory
 from lookup_license.ll_shell import LookupLicenseShell
 from lookup_license.format import FormatterFactory
+from lookup_license.cache import LookupLicenseCache
+
 import lookup_license.config
 
 def get_parser():
@@ -37,6 +39,11 @@ def get_parser():
     parser.add_argument('-of', '--output-format',
                         type=str,
                         default='text')
+
+    parser.add_argument('-nc', '--no-cache',
+                        action='store_true',
+                        help='don±\'t use cache ',
+                        default=False)
 
     parser.add_argument('-f', '--file',
                         action='store_true',
@@ -150,6 +157,10 @@ def main():
     if args.verbose > 2:
         logging.basicConfig(force=True, level=logging.DEBUG)
 
+    if args.no_cache:
+        LookupLicenseCache().disable()
+        
+        
     ll = LookupLicense()
 
     try:

--- a/lookup_license/__main__.py
+++ b/lookup_license/__main__.py
@@ -42,7 +42,7 @@ def get_parser():
 
     parser.add_argument('-nc', '--no-cache',
                         action='store_true',
-                        help='don±\'t use cache ',
+                        help='don\'t use cache ',
                         default=False)
 
     parser.add_argument('--clear-cache',

--- a/lookup_license/cache.py
+++ b/lookup_license/cache.py
@@ -1,41 +1,63 @@
+# SPDX-FileCopyrightText: 2025 Henrik Sandklef
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from pathlib import Path
 from diskcache import Cache
 
+import logging
+
 class LookupLicenseCache():
 
-    def __init__(self):
-        self.cache = None
+    def _init_cache(self, update=False):
+        logging.debug('LookupLicenseCache _init_cache')
+        self.cache = Cache(f'{Path.home()}/.ll/')
+        self.enabled = True
+        self.update_mode = True
 
-    def _init_cache(self):
-        if not self.cache:
-            self.cache = Cache(f'{Path.home()}/.ll/')
+    def set_update_mode(self, enable_update=True):
+        self.update_mode = enable_update
+
+    def disable(self):
+        self.enabled = False
+
+    def enable(self):
+        self.enabled = True
 
     def add(self, key, value):
-        self._init_cache()
-        self.cache.add(key, value)
-    
+        if not self.enabled:
+            logging.debug("LookupLicenseCache is disabled, will not store ")
+        logging.debug(f'LookupLicenseCache add {key}')
+
+        if not self.cache.add(key, value):
+            if self.update_mode:
+                self.cache.set(key, value)
+                logging.debug('LookupLicenseCache updated: {key}')
+        else:
+            logging.debug('LookupLicenseCache added: {key}')
+            logging.debug('LookupLicenseCache Objects in cache: {self.cache.size}')
+
+    def get(self, key):
+        logging.debug(f'LookupLicenseCache get {key}')
+        if not self.enabled:
+            raise Exception("LookupLicenseCache is disabled")
+        if self.update_mode:
+            raise Exception("LookupLicenseCache update mode enabled")
+
+        return self.cache[key]
+
     def close(self):
-        self._init_cache()
         self.cache.close()
-    
+
+    def clear(self):
+        self.cache.clear()
+
     def __new__(cls):
         if not hasattr(cls, 'llcache'):
+            logging.debug('Creating LookupLicenseCache object')
             cls.llcache = super(LookupLicenseCache, cls).__new__(cls)
+            cls.llcache._init_cache()
         return cls.llcache
 
-    def list(self):
-        self._init_cache()
-        return list(self.cache)
-
-
-cache = LookupLicenseCache()
-cache = LookupLicenseCache()
-cache = LookupLicenseCache()
-cache = LookupLicenseCache()
-cache = LookupLicenseCache()
-
-cache.add("hesa", "ksksk")
-
-print(str(cache.list()))
-
-cache.close()
+    def cache(self):
+        return self.cache

--- a/lookup_license/cache.py
+++ b/lookup_license/cache.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+from diskcache import Cache
+
+class LookupLicenseCache():
+
+    def __init__(self):
+        self.cache = None
+
+    def _init_cache(self):
+        if not self.cache:
+            self.cache = Cache(f'{Path.home()}/.ll/')
+
+    def add(self, key, value):
+        self._init_cache()
+        self.cache.add(key, value)
+    
+    def close(self):
+        self._init_cache()
+        self.cache.close()
+    
+    def __new__(cls):
+        if not hasattr(cls, 'llcache'):
+            cls.llcache = super(LookupLicenseCache, cls).__new__(cls)
+        return cls.llcache
+
+    def list(self):
+        self._init_cache()
+        return list(self.cache)
+
+
+cache = LookupLicenseCache()
+cache = LookupLicenseCache()
+cache = LookupLicenseCache()
+cache = LookupLicenseCache()
+cache = LookupLicenseCache()
+
+cache.add("hesa", "ksksk")
+
+print(str(cache.list()))
+
+cache.close()

--- a/lookup_license/lookupurl/gem.py
+++ b/lookup_license/lookupurl/gem.py
@@ -113,7 +113,7 @@ class Gem(LookupURL):
 
         return json_data['version']
 
-    def lookup_url(self, url):
+    def lookup_url_impl(self, url):
 
         url = url.strip('/')
 

--- a/lookup_license/lookupurl/gitrepo.py
+++ b/lookup_license/lookupurl/gitrepo.py
@@ -174,7 +174,7 @@ class GitRepo(LookupURL):
                 suggestions.append(self._suggest_license_files(repo_url, url_source, branch))
         return suggestions
 
-    def lookup_url(self, url):
+    def lookup_url_impl(self, url):
         if url.startswith('pkg:'):
             # purl
             purl_object = PackageURL.from_string(url)

--- a/lookup_license/lookupurl/lookupurl.py
+++ b/lookup_license/lookupurl/lookupurl.py
@@ -4,6 +4,7 @@
 
 from lookup_license.lookuplicense import LookupLicense
 from lookup_license.retrieve import Retriever
+from lookup_license.cache import LookupLicenseCache
 
 import logging
 
@@ -14,6 +15,18 @@ class LookupURL:
         self.lookup_license = LookupLicense()
 
     def lookup_url(self, url):
+        try:
+            return LookupLicenseCache().get(url)
+        except Exception as e:
+            logging.debug(f'lookup_url: failed to get data from cache for {url}, {e}')
+
+        ret = self.lookup_url_impl(url)
+        logging.debug(f'add to cache: {url}')
+        LookupLicenseCache().add(url, ret)
+
+        return ret
+
+    def lookup_url_impl(self, url):
         return self.lookup_license_urls(url, [[url]])
 
     def lookup_license_urls(self, url, suggestions):

--- a/lookup_license/lookupurl/purl.py
+++ b/lookup_license/lookupurl/purl.py
@@ -92,7 +92,7 @@ class Purl(LookupURL):
 
         return None
 
-    def lookup_url(self, url):
+    def lookup_url_impl(self, url):
         logging.debug('Purl: lookup_url')
 
         purl_handler = self._purl_handler(url)

--- a/lookup_license/lookupurl/pypi.py
+++ b/lookup_license/lookupurl/pypi.py
@@ -116,7 +116,7 @@ class Pypi(LookupURL):
             if _data:
                 return _data
 
-    def lookup_url(self, url):
+    def lookup_url_impl(self, url):
 
         url = url.strip('/')
 

--- a/lookup_license/lookupurl/swift.py
+++ b/lookup_license/lookupurl/swift.py
@@ -155,7 +155,7 @@ class Swift(LookupURL):
             'repo_suggestions': url_suggestions,
         }
 
-    def lookup_url(self, url):
+    def lookup_url_impl(self, url):
         # Try identifying the purl in swiftpackageindex.com
         swiftpackageindex_data = self._try_swiftpackageindex(url)
         if swiftpackageindex_data:

--- a/lookup_license/lookupurl/url.py
+++ b/lookup_license/lookupurl/url.py
@@ -14,7 +14,7 @@ class Url(LookupURL):
         self.gitrepo = GitRepo()
         super().__init__()
 
-    def lookup_url(self, url):
+    def lookup_url_impl(self, url):
         urls = {
             'license_raw_url': self.gitrepo.raw_content_url(url),
             'original_url': url,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ packageurl-python
 license_expression
 #charset-normalizer==2.1.0
 diskcache
-packageurl
+packageurl-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ requests==2.28.1
 packageurl-python
 license_expression
 #charset-normalizer==2.1.0
+diskcache
+packageurl

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     license_files=('LICENSES/GPL-3.0-or-later.txt',),
     url="https://github.com/hesa/lookup-license",
-    packages=['lookup_license', 'lookup_license.lookupurl', ],
+    packages=['lookup_license', 'lookup_license.lookupurl'],
     entry_points={
         "console_scripts": [
             "lookup-license=lookup_license.__main__:main",


### PR DESCRIPTION
These commits add support for caching URL lookups (e.g. gitrepo, pypi package, purl).

New options:
* `--no-cache`
* `--clear-cache`
* `--update-cache`
